### PR TITLE
fix(ci): restrict npm publishing to tags

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -55,6 +55,10 @@ jobs:
         run: make tgz
         working-directory: ./wasm
 
+      - name: Validate npm package contents
+        run: npm pack --dry-run
+        working-directory: ./wasm
+
       - name: Upload npm package as artifact
         uses: actions/upload-artifact@v7
         with:
@@ -74,6 +78,7 @@ jobs:
 
   publish:
     needs: build
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     environment:
       name: npmjs
@@ -89,9 +94,5 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: libspot-tgz
-      - name: Stage publish (dry-run)
-        if: github.ref_type != 'tag'
-        run: npm stage publish --dry-run libspot*.tgz
       - name: Stage publish
-        if: github.ref_type == 'tag'
         run: npm stage publish libspot*.tgz


### PR DESCRIPTION
## Summary

- keep generating the npm tarball during every JS build
- validate package contents with `npm pack --dry-run` in the build job
- skip the entire publish job unless the workflow runs for a tag
- retain staged npm publishing for tagged releases

## Why

`npm stage publish --dry-run` still performs registry-level version validation. Pull requests build the currently released package version, so npm 11.17 rejects the dry run when that version already exists. Package validation in pull requests should not depend on registry state or publishing credentials.

## Tests

- `git diff --check`
- GitHub Actions JS workflow
